### PR TITLE
Add configurable thresholds and multi-cryptocurrency support (Closes #1)

### DIFF
--- a/price_alert.py
+++ b/price_alert.py
@@ -1,20 +1,40 @@
 import requests
+import json
+import os
 
 
 def get_price(symbol):
+    """
+    Fetch the current USD price for a given cryptocurrency symbol using CoinGecko API.
+    """
     url = f'https://api.coingecko.com/api/v3/simple/price?ids={symbol}&vs_currencies=usd'
     response = requests.get(url)
     data = response.json()
     return data[symbol]['usd']
 
 
-def main():
-    # Define symbols and their alert thresholds in USD
-    watch = {
+def load_config():
+    """
+    Load alert thresholds from a local JSON configuration file. If the file does not exist,
+    return a default configuration. This allows users to customize which cryptocurrencies to
+    monitor and their alert thresholds without modifying the script.
+    """
+    config_file = 'config.json'
+    if os.path.exists(config_file):
+        with open(config_file, 'r') as f:
+            return json.load(f)
+    # Default configuration if no config file is found
+    return {
         'bitcoin': 30000,
-        'ethereum': 2000
+        'ethereum': 2000,
+        'dogecoin': 0.1
     }
-    for symbol, threshold in watch.items():
+
+
+def main():
+    # Load the watchlist from config
+    watchlist = load_config()
+    for symbol, threshold in watchlist.items():
         price = get_price(symbol)
         if price >= threshold:
             print(f"ALERT: {symbol.capitalize()} price ${price} has reached or exceeded threshold ${threshold}")


### PR DESCRIPTION
This pull request enhances the price alert script by loading alert thresholds and cryptocurrencies from a JSON config file. It allows users to monitor multiple cryptocurrencies (e.g., Bitcoin, Ethereum, Dogecoin) with customizable thresholds.

- Adds a `load_config` function that reads `config.json` if present, or provides default thresholds.
- Iterates over each symbol/threshold pair and prints alerts when the price meets or exceeds the threshold.
- Closes issue #1.
